### PR TITLE
issue#66: prevent IndexOutOfBoundsException in MM1Queue network with more than 1 host in edge datacenter

### DIFF
--- a/src/edu/boun/edgecloudsim/network/MM1Queue.java
+++ b/src/edu/boun/edgecloudsim/network/MM1Queue.java
@@ -114,12 +114,23 @@ public class MM1Queue extends NetworkModel {
 		//edge device (wifi access point) to mobile device
 		else{
 			delay = getWlanDownloadDelay(accessPointLocation, CloudSim.clock());
+			
+			/* using a running total of hosts (hostCounter), sequentially search for the datacenter (datacenterIndex) where 
+			the host (sourceDeviceId) is located, then use that datacenter index to retrieve the host */
 
-			EdgeHost host = (EdgeHost)(SimManager.
-					getInstance().
-					getEdgeServerManager().
-					getDatacenterList().get(sourceDeviceId).
-					getHostList().get(0));
+			EdgeHost host = null;
+			int hostCounter = 0;
+			for(int datacenterIndex=0; datacenterIndex<SimSettings.getInstance().getNumOfEdgeDatacenters(); datacenterIndex++) {
+				
+				hostCounter += SimManager.getInstance().getEdgeServerManager().
+										  getDatacenterList().get(datacenterIndex).getHostList().size();
+				
+				if(hostCounter  >= sourceDeviceId) {
+					host = (EdgeHost)(SimManager.getInstance().getEdgeServerManager().
+												 getDatacenterList().get(datacenterIndex).getHostList().get(0));
+					break;
+				}
+			}
 
 			//if source device id is the edge server which is located in another location, add internal lan delay
 			//in our scenario, serving wlan ID is equal to the host id, because there is only one host in one place


### PR DESCRIPTION
This is a proposed fix for issue #66

Tested on _sample_app1_ with 2 hosts in one of the datacenters (in _edge_devices.xml_).